### PR TITLE
Have players emit "end" before they are destroyed.

### DIFF
--- a/src/lib/Manager.ts
+++ b/src/lib/Manager.ts
@@ -120,7 +120,7 @@ export class Manager extends EventEmitter {
         await this.sendWS(guild, null);
         const player = this.players.get(guild);
         if (!player) return false;
-        if (player.listenerCount("end") && player.playing) player.emit("end", "destroy");
+        if (player.listenerCount("end") && player.playing) player.emit("end", {"type":"TrackEndEvent", "reason":"STOPPED"});
         player.removeAllListeners();
         await player.destroy();
         return this.players.delete(guild);

--- a/src/lib/Manager.ts
+++ b/src/lib/Manager.ts
@@ -120,7 +120,7 @@ export class Manager extends EventEmitter {
         await this.sendWS(guild, null);
         const player = this.players.get(guild);
         if (!player) return false;
-        if (player.listenerCount("end") && player.playing) player.emit("end", {"type":"TrackEndEvent", "reason":"STOPPED"});
+        if (player.listenerCount("end") && player.playing) player.emit("end", { "type":"TrackEndEvent", "reason":"STOPPED" });
         player.removeAllListeners();
         await player.destroy();
         return this.players.delete(guild);

--- a/src/lib/Manager.ts
+++ b/src/lib/Manager.ts
@@ -120,7 +120,7 @@ export class Manager extends EventEmitter {
         await this.sendWS(guild, null);
         const player = this.players.get(guild);
         if (!player) return false;
-        if (player.listenerCount("end") && player.playing) player.emit("end", { type: "TrackEndEvent", reason: "STOPPED" });
+        if (player.listenerCount("end") && player.playing) player.emit("end", { type: "TrackEndEvent", reason: "CLEANUP" });
         player.removeAllListeners();
         await player.destroy();
         return this.players.delete(guild);

--- a/src/lib/Manager.ts
+++ b/src/lib/Manager.ts
@@ -120,7 +120,7 @@ export class Manager extends EventEmitter {
         await this.sendWS(guild, null);
         const player = this.players.get(guild);
         if (!player) return false;
-        if (player.listenerCount("end") && player.playing) player.emit("end", { "type":"TrackEndEvent", "reason":"STOPPED" });
+        if (player.listenerCount("end") && player.playing) player.emit("end", { type: "TrackEndEvent", reason: "STOPPED" });
         player.removeAllListeners();
         await player.destroy();
         return this.players.delete(guild);

--- a/src/lib/Manager.ts
+++ b/src/lib/Manager.ts
@@ -120,6 +120,7 @@ export class Manager extends EventEmitter {
         await this.sendWS(guild, null);
         const player = this.players.get(guild);
         if (!player) return false;
+        if (player.listenerCount("end") && player.playing) player.emit("end", "destroy");
         player.removeAllListeners();
         await player.destroy();
         return this.players.delete(guild);


### PR DESCRIPTION
As end is emitted when a track is finished playing or can be played no further, I figured it would be appropriate to emit "end" when the track is ended by the player being destroyed.
This is useful for tracking duration, as then the duration count can be reset.

~It may, however, cause issues if a developer has their queue shift whenever end is emitted and they do not want the current track to be removed from the queue, this can be solved by checking if "destroy" is the passed argument.
Another issue that may arise is if the program expects a packet (and not "destroy"), which may lead to unexpected behavior, this can also be solved easily.
These possible consequences likely wont be seen often, but I just wanted to point them out for consideration.~

Once again, I'm not sure if what I have written will function correctly in typescript (despite it being so little haha), but it'll go through due process anyway.

Edit: Changed from just "destroy" to a LavalinkEvent to comply with the documentation, not sure if it used correctly though.