### PR TITLE
Allow moving bots between channels.

### DIFF
--- a/src/lib/Manager.ts
+++ b/src/lib/Manager.ts
@@ -163,6 +163,11 @@ export class Manager extends EventEmitter {
         if (data.user_id !== this.user) return Promise.resolve(false);
 
         if (data.channel_id) {
+            if (this.voiceStates.get(data.guild_id) !== undefined) {
+                if (data.channel_id !== this.voiceStates.get(data.guild_id).channel_id) {
+                    return this.voiceStates.set(data.guild_id, data);
+                }
+            }
             this.voiceStates.set(data.guild_id, data);
             return this._attemptConnection(data.guild_id);
         }


### PR DESCRIPTION
Currently when bot is moved from one channel to another player disconnects. This fixes the issue.