### PR TITLE
build(tsconfig): dont remove comments

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
 			"noUnusedLocals": true,
 			"outDir": "./dist",
 			"pretty": true,
-			"removeComments": true,
+			"removeComments": false,
 			"resolveJsonModule": true,
 			"sourceMap": true,
 			"strictFunctionTypes": true,


### PR DESCRIPTION
Removing comments also removes them in type declarations thus removing them from VSCode IntelliSense. This is extremely annoying tbh.

If you want to remove code from the source JS files then use a packager like Rollup to minify the source code tbh.