### PR TITLE
[Fix/Docs] Do not set LavalinkNode.ws as null in LavalinkNode.destroy

### DIFF
--- a/src/lib/LavalinkNode.ts
+++ b/src/lib/LavalinkNode.ts
@@ -159,12 +159,11 @@ export class LavalinkNode {
     }
 
     /**
-     * Destorys the connection to the Lavalink Websocket
+     * Destroys the connection to the Lavalink Websocket
      */
     public destroy(): boolean {
         if (!this.connected) return false;
         this.ws!.close(1000, "destroy");
-        this.ws = null;
         return true;
     }
 


### PR DESCRIPTION
Setting this as null causes a crash if unhandled when trying to access a property of the ws in another method when the node is actually destroyed. The public LavalinkNode.connect reassigns the LavalinkNode.ws property anyways, which would cause the old data to be swept (if leaving a memory footprint was a concern in the first place).