### PR TITLE
Add "Client-Name" to ws handshake headers

### DIFF
--- a/src/lib/LavalinkNode.ts
+++ b/src/lib/LavalinkNode.ts
@@ -2,6 +2,7 @@ import WebSocket from "ws";
 import { Manager } from "./Manager";
 import { Player } from "./Player";
 import { LavalinkNodeOptions, LavalinkStats, QueueData, WebsocketCloseEvent } from "./Types";
+import pack from "../../package.json";
 
 /**
  * The class for handling everything to do with connecting to Lavalink
@@ -104,7 +105,8 @@ export class LavalinkNode {
             const headers: Record<string, string> = {
                 Authorization: this.password,
                 "Num-Shards": String(this.manager.shards || 1),
-                "User-Id": this.manager.user!
+                "User-Id": this.manager.user!,
+                "Client-Name": `${pack.name}/${pack.version}`
             };
 
             if (this.resumeKey) headers["Resume-Key"] = this.resumeKey;


### PR DESCRIPTION
Add the required "Client-Name" header for ws connections as stated in [IMPLEMENTATION.md](https://github.com/freyacodes/Lavalink/blob/092f602b787307b78e7b78625121ba56d2723f54/IMPLEMENTATION.md#opening-a-connection)