### PR TITLE
Add the option for selecting nodes based off VOICE_SERVER_UPDATE endpoint region

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install lavacord/lavacord
 ## LavaLink configuration
 Download from [the CI server](https://ci.fredboat.com/viewLog.html?buildId=lastSuccessful&buildTypeId=Lavalink_Build&tab=artifacts&guest=1)
 
-Put an `application.yml` file in your working directory. [Example](https://github.com/Frederikam/Lavalink/blob/master/LavalinkServer/application.yml.example)
+Put an `application.yml` file in your working directory. [Example](https://github.com/freyacodes/Lavalink/blob/master/LavalinkServer/application.yml.example)
 
 Run with `java -jar Lavalink.jar`
 

--- a/src/lib/LavalinkNode.ts
+++ b/src/lib/LavalinkNode.ts
@@ -48,7 +48,16 @@ export class LavalinkNode {
      * Extra info attached to your node, not required and is not sent to lavalink, purely for you.
      */
     public state?: any;
-
+    /**
+     * The Discord VOICE_SERVER_UPDATE regions this node should cover.
+     * The regions are regexed out of the url you send to LavaLink in the format of:
+     * /^([\w-]+)\d+\./
+     *
+     * Example VOICE_SERVER_UPDATE packet region: us-west4887.discord.media:443
+     *
+     * What you would put: ["us-west"] to only cover us-west
+     */
+    public regions?: string[];
     /**
      * The reconnect timeout
      * @private
@@ -75,6 +84,7 @@ export class LavalinkNode {
         if (options.resumeKey) this.resumeKey = options.resumeKey;
         if (options.resumeTimeout) this.resumeTimeout = options.resumeTimeout;
         if (options.state) this.state = options.state;
+        if (options.regions) this.regions = options.regions;
 
         this.stats = {
             players: 0,

--- a/src/lib/LavalinkNode.ts
+++ b/src/lib/LavalinkNode.ts
@@ -51,7 +51,7 @@ export class LavalinkNode {
     /**
      * The Discord VOICE_SERVER_UPDATE regions this node should cover.
      * The regions are regexed out of the url you send to LavaLink in the format of:
-     * /^([\w-]+)\d+\./
+     * /^([^\d]+)\d+\./
      *
      * Example VOICE_SERVER_UPDATE packet region: us-west4887.discord.media:443
      *

--- a/src/lib/Manager.ts
+++ b/src/lib/Manager.ts
@@ -114,9 +114,11 @@ export class Manager extends EventEmitter {
     public async join(data: JoinData, joinOptions: JoinOptions = {}): Promise<Player> {
         const player = this.players.get(data.guild);
         if (player) return player;
+        let promise: Promise<string | Error> | undefined;
+        if (!data.node) promise = new Promise<string | Error>(resolve => this.selectPromises.set(data.guild, resolve));
         await this.sendWS(data.guild, data.channel, joinOptions);
-        if (!data.node) {
-            const node = await new Promise<string | Error>(resolve => this.selectPromises.set(data.guild, resolve));
+        if (promise) {
+            const node = await promise;
             if (node instanceof Error) throw node;
             data.node = node;
         }

--- a/src/lib/Player.ts
+++ b/src/lib/Player.ts
@@ -142,7 +142,7 @@ export class Player extends EventEmitter {
 
     /**
      * Sets the equalizer of the current song, if you wanted to do something like bassboost
-     * @param bands The bands that you want lavalink to modify read [IMPLEMENTATION.md](https://github.com/Frederikam/Lavalink/blob/master/IMPLEMENTATION.md#outgoing-messages) for more information
+     * @param bands The bands that you want lavalink to modify read [IMPLEMENTATION.md](https://github.com/freyacodes/Lavalink/blob/master/IMPLEMENTATION.md#outgoing-messages) for more information
      */
     public async equalizer(bands: PlayerEqualizerBand[]): Promise<boolean> {
         const newFilters = Object.assign(this.state.filters, { equalizer: bands });

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -148,9 +148,9 @@ export interface JoinData {
      */
     channel: string;
     /**
-     * The LavalinkNode ID you want to use
+     * The LavalinkNode ID you want to use. None to auto determine based off region if defined
      */
-    node: string;
+    node?: string;
 }
 
 /**
@@ -285,6 +285,16 @@ export interface LavalinkNodeOptions {
      * Extra info attached to your node, not required and is not sent to lavalink, purely for you.
      */
     state?: any;
+    /**
+     * The Discord VOICE_SERVER_UPDATE regions this node should cover.
+     * The regions are regexed out of the url you send to LavaLink in the format of:
+     * /^([\w-]+)\d+\./
+     *
+     * Example VOICE_SERVER_UPDATE packet region: us-west4887.discord.media:443
+     *
+     * What you would put: ["us-west"] to only cover us-west
+     */
+    regions?: string[];
 }
 
 /**

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -288,7 +288,7 @@ export interface LavalinkNodeOptions {
     /**
      * The Discord VOICE_SERVER_UPDATE regions this node should cover.
      * The regions are regexed out of the url you send to LavaLink in the format of:
-     * /^([\w-]+)\d+\./
+     * /^([^\d]+)\d+\./
      *
      * Example VOICE_SERVER_UPDATE packet region: us-west4887.discord.media:443
      *


### PR DESCRIPTION
For whatever reason, git decided to include the commit where I updated the links to freyacodes/LavaLink in this PR, but shouldn't be too much of an issue with a squash merge.

This has been tested to work.

This does require the user to define regions and does not offer fallback to a random node because it may be unintentional, although not all of the regions shown through the VOICE_SERVER_UPDATE endpoint field are displayed somewhere. I plan to create a table of regions I personally have seen. Although, the lib will display the region it could not select, so new nodes could be added to the map as they're created